### PR TITLE
Fix missing tf2_sensor_msgs dependency for ROS 2 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 find_package(ament_cmake_auto REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(tf2_sensor_msgs REQUIRED)
 find_package(PCL REQUIRED)
 ament_auto_find_build_dependencies()
 

--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>ndt_omp</depend>
+  <depend>tf2_sensor_msgs</depend>
+
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This PR fixes a ROS 2 build failure caused by a missing tf2_sensor_msgs dependency.

The header <tf2_sensor_msgs/tf2_sensor_msgs.h> is included in ndt_localization,
but the package was not declared in CMakeLists.txt or package.xml, causing
compilation to fail on clean ROS 2 environments.

Changes:
- Add find_package(tf2_sensor_msgs REQUIRED)
- Declare tf2_sensor_msgs in package.xml

Tested on ROS 2 Humble with colcon build.

Fixes for issue #9 
